### PR TITLE
Allow customer container names via configuruation

### DIFF
--- a/AutoNumber/Options/AutoNumberOptions.cs
+++ b/AutoNumber/Options/AutoNumberOptions.cs
@@ -13,7 +13,7 @@ public class AutoNumberOptions
 
     public string DatabaseId { get; set; }
 
-    public string ContainerName => "autoNumberStates";
+    public string ContainerName { get; set; } = "autoNumberStates";
 
     public string ConnectionString { get; set; }
         

--- a/AutoNumber/Options/AutoNumberOptionsBuilder.cs
+++ b/AutoNumber/Options/AutoNumberOptionsBuilder.cs
@@ -70,6 +70,16 @@ public class AutoNumberOptionsBuilder
     }
 
     /// <summary>
+    ///     Set Cosmos Container Name
+    /// </summary>
+    /// <param name="containerName">Container name to use for maning identifiers</param>
+    public AutoNumberOptionsBuilder SetContainerName(string containerName)
+    {
+        Options.ContainerName = containerName;
+        return this;
+    }
+
+    /// <summary>
     ///     Set Cosmos Database Id
     /// </summary>
     /// <param name="databaseId">Database identifier</param>


### PR DESCRIPTION
Problem:
There wasn't a way to use a different container name than "autoNumberStates".

Solution:
Make the container name set-able and add a step to set the container name via the `AutoNumberOptionsBuilder`